### PR TITLE
download buttons: read data/nightly.json, fall back to the GitHub API

### DIFF
--- a/data/nightly.json
+++ b/data/nightly.json
@@ -1,0 +1,64 @@
+{
+ "schema": 1,
+ "generated": "2026-08-29T14:16:19Z",
+ "channel": "nightly",
+ "repo": "aurelienpierreeng/ansel",
+ "download_page": "https://ansel.photos/en/download/",
+ "formats": {
+  "appimage": {
+   "name": "Ansel-0.0.0+4791.gf3a0c27035-x86_64.AppImage",
+   "url": "https://github.com/aurelienpierreeng/ansel/releases/download/v0.0.0/Ansel-0.0.0%2B4791.gf3a0c27035-x86_64.AppImage",
+   "size": 262916600,
+   "uploaded": "2026-08-29T11:43:23Z",
+   "release": "v0.0.0",
+   "version": "0.0.0+4791.gf3a0c27035",
+   "commit_short": "f3a0c27035",
+   "sha256": "7ce2afdfa73a1f3eec0ef46c70986940b94f85bfb35ef82fb0521d4e44c5cd34",
+   "commit": "f3a0c27035a8bf6f40306de3872afba55ec7dae3"
+  },
+  "dmg-arm64": {
+   "name": "Ansel-0.0.0+4791.gf3a0c27035-arm64.dmg",
+   "url": "https://github.com/aurelienpierreeng/ansel/releases/download/v0.0.0/Ansel-0.0.0%2B4791.gf3a0c27035-arm64.dmg",
+   "size": 146148474,
+   "uploaded": "2026-08-29T11:49:13Z",
+   "release": "v0.0.0",
+   "version": "0.0.0+4791.gf3a0c27035",
+   "commit_short": "f3a0c27035",
+   "sha256": "0b31d2ea73ecf782a887461cc2f42b659c0d95e4545ecab6ec6c7384d812b809",
+   "commit": "f3a0c27035a8bf6f40306de3872afba55ec7dae3"
+  },
+  "dmg-i386": {
+   "name": "Ansel-0.0.0+4791.gf3a0c27035-i386.dmg",
+   "url": "https://github.com/aurelienpierreeng/ansel/releases/download/v0.0.0/Ansel-0.0.0%2B4791.gf3a0c27035-i386.dmg",
+   "size": 148738813,
+   "uploaded": "2026-08-29T11:49:08Z",
+   "release": "v0.0.0",
+   "version": "0.0.0+4791.gf3a0c27035",
+   "commit_short": "f3a0c27035",
+   "sha256": "19df4b110f9fe4244fd6e6c6536adc2ebaf450346211a624576d991ca661af8b",
+   "commit": "f3a0c27035a8bf6f40306de3872afba55ec7dae3"
+  },
+  "exe": {
+   "name": "ansel-0.0.0+4791.gf3a0c27035-win64.exe",
+   "url": "https://github.com/aurelienpierreeng/ansel/releases/download/v0.0.0/ansel-0.0.0%2B4791.gf3a0c27035-win64.exe",
+   "size": 154682079,
+   "uploaded": "2026-08-29T11:44:26Z",
+   "release": "v0.0.0",
+   "version": "0.0.0+4791.gf3a0c27035",
+   "commit_short": "f3a0c27035",
+   "sha256": "d896f12a5b91077c722175186582a1b67e03747c8a34ea1433e84a9c5f4f3db3",
+   "commit": "f3a0c27035a8bf6f40306de3872afba55ec7dae3"
+  },
+  "flatpak": {
+   "name": "Ansel-0.0.0+4802.gd5a317e072-x86_64.flatpak",
+   "url": "https://github.com/aurelienpierreeng/ansel/releases/download/v0.0.0/Ansel-0.0.0%2B4802.gd5a317e072-x86_64.flatpak",
+   "size": 98986072,
+   "uploaded": "2026-08-29T12:00:45Z",
+   "release": "v0.0.0",
+   "version": "0.0.0+4802.gd5a317e072",
+   "commit_short": "d5a317e072",
+   "sha256": "4fe78c789c0b058a3a61a12b14569ed75f5613ec798345bdc91d8063a8fd4d82",
+   "commit": "d5a317e072ac6d3d304f462e6057835e2b68288c"
+  }
+ }
+}

--- a/themes/ansel/layouts/shortcodes/release-assets.html
+++ b/themes/ansel/layouts/shortcodes/release-assets.html
@@ -31,42 +31,66 @@
   {{- end -}}
 {{- end -}}
 
-{{- $apiURL := printf "https://api.github.com/repos/%s/releases/tags/%s" $repoSlug $releaseTag -}}
+{{- /*
+  Source of truth: data/nightly.json, written to this repository by Ansel's nightly CI
+  (tools/nightly_manifest.py in aurelienpierreeng/ansel) after every build. It names the
+  newest build of every format, so the download buttons need no GitHub API call at build
+  time -- no token, no rate limit, no dependency on api.github.com being reachable.
+
+  The manifest is keyed by format; this shortcode is called with a filename extension, so
+  the extension is matched against each entry's filename. `offset` (previous builds) is
+  not something the manifest carries: it lists the newest only, and the API fallback below
+  still answers offset > 0 the old way.
+
+  The API path is kept as the fallback for that, and for the day the data file is missing
+  or stale (a CI outage): a page that shows last night's build beats one with no button.
+*/ -}}
+{{- $matches := slice -}}
+{{- $manifest := site.Data.nightly -}}
+{{- if and $manifest (eq $offset 0) -}}
+  {{- range $key, $entry := $manifest.formats -}}
+    {{- $name := $entry.name | default "" | lower -}}
+    {{- if and $entry.url (hasSuffix $name $extension) -}}
+      {{- $matches = $matches | append (dict "name" $name "url" $entry.url "date" ($entry.uploaded | default "")) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if not $matches -}}
+{{- $apiURL := printf "https://api.github.com/repos/%s/releases?per_page=3" $repoSlug -}}
 {{- $headers := dict "Accept" "application/vnd.github+json" "User-Agent" "AnselWebsite" -}}
 {{- if $token -}}
   {{- $headers = merge $headers (dict "Authorization" (printf "Bearer %s" $token)) -}}
 {{- end -}}
-
 {{- $resource := false -}}
 {{- with try (resources.GetRemote $apiURL (dict "headers" $headers)) -}}
   {{- if .Err -}}
-    {{- warnf "Failed to fetch GitHub release %q: %s" $apiURL .Err -}}
+    {{- warnf "Failed to fetch GitHub releases %q: %s" $apiURL .Err -}}
   {{- else -}}
     {{- $resource = .Value -}}
   {{- end -}}
 {{- end -}}
-{{- $releaseData := dict -}}
+{{- /* Newest releases first; the nightly-YYYY-MM pre-releases rotate monthly, so the
+       previous build may sit in the previous month's release on the first of a month. */ -}}
 {{- with $resource -}}
-  {{- $releaseData = .Content | transform.Unmarshal -}}
-{{- end -}}
-
-{{- $matches := slice -}}
-{{- with $releaseData.assets -}}
-  {{- range . -}}
-    {{- $name := .name | lower -}}
-    {{- $downloadURL := .browser_download_url -}}
-    {{- if and $downloadURL (not (strings.Contains $name "source")) (hasSuffix $name $extension) -}}
-      {{- $assetDate := .updated_at | default .created_at | default "" -}}
-      {{- $matches = $matches | append (dict "name" $name "url" $downloadURL "date" $assetDate) -}}
+  {{- range .Content | transform.Unmarshal -}}
+    {{- with .assets -}}
+      {{- range . -}}
+        {{- $name := .name | lower -}}
+        {{- $downloadURL := .browser_download_url -}}
+        {{- if and $downloadURL (not (strings.Contains $name "source")) (hasSuffix $name $extension) -}}
+          {{- $assetDate := .updated_at | default .created_at | default "" -}}
+          {{- $matches = $matches | append (dict "name" $name "url" $downloadURL "date" $assetDate) -}}
+        {{- end -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
-
+{{- end -}}
 {{- $matches = sort $matches "date" "desc" -}}
 {{- $selectedAsset := index $matches $offset -}}
 
 {{ if not $selectedAsset }}
-  {{- $fallbackURL := printf "https://github.com/%s/releases/tag/%s" $repoSlug $releaseTag -}}
+  {{- $fallbackURL := printf "https://github.com/%s/releases" $repoSlug -}}
   <a role="button" class="btn btn-dark my-1" href="{{ $fallbackURL }}">View release assets</a>
 {{ else }}
   {{- $name := index $selectedAsset "name" -}}


### PR DESCRIPTION
Part of aurelienpierreeng/ansel#1320.

Ansel's nightly CI now writes **one manifest** naming the newest build of every format (`tools/nightly_manifest.py`) and pushes it here as `data/nightly.json` after each nightly. The `release-assets` shortcode reads that first, so building the site needs **no GitHub API call, no token and no rate-limit luck**. The same file is served at `ansel.photos/nightly.json`, which is what the in-app update check reads.

The API path stays as the fallback — for `offset` (previous builds, which the manifest does not list) and for a missing or stale data file — and now walks the newest releases instead of the fixed `v0.0.0` tag: nightlies land in one `nightly-YYYY-MM` pre-release per month from now on, and `v0.0.0` stops receiving them.

`data/nightly.json` committed here is today's, generated by hand from the current releases; from tonight the CI overwrites it (needs the `NIGHTLY_PUBLISH_TOKEN` secret on the ansel repo — see the doc there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)